### PR TITLE
Remove quarter option for Archive Search

### DIFF
--- a/app/views/courses/lookup.html.erb
+++ b/app/views/courses/lookup.html.erb
@@ -12,10 +12,6 @@
            <%= text_field_tag :course_q, params[:course_q], class: "form-control"%>
          </div>       
          <div class="form-group">
-           <label class="control-label" for="quarter_q">Quarter</label><br/>
-           <%= select_tag(:quarter_q, options_for_select([["Fall", "Fall"],["Winter", "Winter"],["Spring", "Spring"],["Summer", "Summer"]])) %>
-         </div> 
-         <div class="form-group">
            <label class="control-label" for="year_q">Year</label>
            <%= text_field_tag :year_q, params[:year_query], class: "form-control"%>
          </div>

--- a/lib/dmr/course_controller_helper.rb
+++ b/lib/dmr/course_controller_helper.rb
@@ -107,7 +107,6 @@ module Dmr
         inst = params[:instructor_q]
         q = "course LIKE '%ARCHIVE%'"
         q += " AND lower(course) like '%#{params[:course_q].downcase}%'" if !params[:course_q].blank?
-        q += " AND lower(quarter) like '%#{params[:quarter_q].downcase}%'" if !params[:quarter_q].blank?
         q += " AND year like '%#{params[:year_q]}%'" if !params[:year_q].blank?
         q += " AND lower(instructor) like '%#{inst.downcase}%'" if !inst.blank?
         Course.where(q)

--- a/spec/features/course_spec.rb
+++ b/spec/features/course_spec.rb
@@ -564,14 +564,6 @@ feature 'Course' do
     click_on 'Cancel'
     current_path.should == welcome_index_path     
   end
-
-  scenario 'wants to see different order of quarter for archive course search page' do
-    visit lookup_courses_path
-    expect(page).to have_selector('option[1]', :text => 'Fall')
-    expect(page).to have_selector('option[2]', :text => 'Winter')
-    expect(page).to have_selector('option[3]', :text => 'Spring')
-    expect(page).to have_selector('option[4]', :text => 'Summer')      
-  end
       
   scenario 'wants to archive some courses' do
     visit search_courses_path( {:search => 'Test'} )    
@@ -607,7 +599,7 @@ feature 'Course' do
 
     # select courses to unarchive
     visit lookup_courses_path
-    page.select('Spring', match: :first) 
+    fill_in 'year_q', :with => '2015' 
     click_on 'Search'
     expect(page).to have_content("Test Course 1 - ARCHIVE #{@course1.updated_at}")
     expect(page).to have_content("Test Course 2 - ARCHIVE #{@course2.updated_at}")        
@@ -630,7 +622,7 @@ feature 'Course' do
     find('input[value="Archive"]').click
     expect(page).to have_content("Test Course 1 - ARCHIVE #{@course1.updated_at}")  
     visit lookup_courses_path
-    page.select('Spring', match: :first) 
+    fill_in 'year_q', :with => '2015'  
     expect(page).to have_selector('div.ribbon')
     click_on 'Search'
     click_on "Test Course 1 - ARCHIVE #{@course1.updated_at}"
@@ -654,7 +646,6 @@ feature 'Course' do
     click_on 'Archive'
     expect(page).to have_selector('h3', :text => 'Search Courses')
     fill_in 'year_q', :with => '2015'
-    page.select('Spring', match: :first) 
     click_on 'Search'
     expect(page).to have_content('Displaying 1 results')
     expect(page).to have_content("Test Course 1 - ARCHIVE #{@course1.updated_at}")    


### PR DESCRIPTION
Fixes #150 ; refs #150

Remove the Quarter option when in Archiving and conducting a search.

Changes proposed in this pull request:
* Remove the Quarter option in UI
* Remove quarter search
* Update tests
