### PR TITLE
Fix space issue with lising audio

### DIFF
--- a/app/controllers/audios_controller.rb
+++ b/app/controllers/audios_controller.rb
@@ -28,7 +28,7 @@ class AudiosController < ApplicationController
   # POST /audios
   def create
     @audio = Audio.new(audio_params)
-
+    @audio.file_name = params[:audio]['file_name'].delete(' ') if params[:audio]['file_name']
     if @audio.save
       redirect_to edit_audio_path(@audio), notice: 'Audio was successfully created.'
     else
@@ -39,6 +39,8 @@ class AudiosController < ApplicationController
   # PATCH/PUT /audios/1
   def update
     if @audio.update(audio_params)
+      @audio.file_name = params[:audio]['file_name'].delete(' ') if params[:audio]['file_name']
+      @audio.save
       redirect_to edit_audio_path(@audio), notice: 'Audio was successfully updated.'
     else
       render :edit

--- a/app/helpers/audios_helper.rb
+++ b/app/helpers/audios_helper.rb
@@ -7,6 +7,7 @@ require 'net/http'
 #
 module AudiosHelper
   def url_exist?(url_string)
+    url_string = url_string.delete(' ') if url_string
     url = URI.parse(url_string)
     req = Net::HTTP.new(url.host, url.port)
     req.use_ssl = (url.scheme == 'https')

--- a/spec/features/audio_spec.rb
+++ b/spec/features/audio_spec.rb
@@ -215,5 +215,18 @@ feature 'Audio' do
 
     click_on 'Report A Bug'
     expect(page).to have_selector('#mf_placeholder')
-  end                                  
+  end
+  
+  scenario 'wants to create new audio record with space in filename field' do
+    visit new_audio_path
+    fill_in 'Track', :with => 'Test Audio'
+    fill_in 'File Name', :with => 'test space name.mp3'
+    click_on 'Save'
+    expect(page).to have_content('Audio was successfully created.')
+
+    # Check that changes are saved
+    visit audios_path
+    expect(page).to have_content('Test Audio')
+    expect(page).to have_content('testspacename.mp3')                  
+  end                                    
 end


### PR DESCRIPTION
Fixes #159 ; refs #159

Fix the problem playing audio to add to the collection and listing the last 10 Audio Records.

Changes proposed in this pull request:
* Remove space for the filename field when creating new record and updating existing record.
* Remove space in the thumbnail url.

@ucsdlib/developers - please review
