### PR TITLE
Add "End Date" to Create New Audio and Video templates

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,7 +27,7 @@ Style/Documentation:
     - 'spec/**/*'
 
 Metrics/LineLength:
-  Max: 106
+  Max: 113
   Exclude:
     - 'app/controllers/users/sessions_controller.rb'  
 

--- a/app/controllers/audios_controller.rb
+++ b/app/controllers/audios_controller.rb
@@ -80,6 +80,6 @@ class AudiosController < ApplicationController
 
   # Never trust parameters from the scary internet, only allow the white list through.
   def audio_params
-    params.require(:audio).permit(:track, :album, :artist, :composer, :call_number, :year, :file_name)
+    params.require(:audio).permit(:track, :album, :artist, :composer, :call_number, :year, :file_name, :end_date)
   end
 end

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -105,7 +105,7 @@ class MediaController < ApplicationController
   #
   def media_params
     params.require(:media).permit(:title, :director, :call_number, :year,
-                                  :file_name, course_ids: [])
+                                  :file_name, :end_date, course_ids: [])
   end
 
   # Use callbacks to share common setup or constraints between actions.

--- a/app/views/audios/_form.html.erb
+++ b/app/views/audios/_form.html.erb
@@ -9,3 +9,8 @@
 <div class="required">  
 <%= f.text_field :file_name, label: "File Name" %>
 </div>
+<div class="form-group">
+  <% e_date = @audio.end_date ? @audio.end_date : ""%>
+  <label class="control-label" for="audio_end_date">End Date</label>
+  <input type="text" name="audio[end_date]" id="audio_end_date" value="<%= e_date%>" size="20" placeholder="YYYY-MM-DD" class="enddatepicker form-control" data-date-format="yyyy-mm-dd"/>
+</div> 

--- a/app/views/audios/_search_result.html.erb
+++ b/app/views/audios/_search_result.html.erb
@@ -30,7 +30,7 @@
        				<%=image_tag "speaker.gif", :alt => '', :class => 'search-thumbnail' %>
     				  <% end %>                
                 </td>          
-                <td><%= link_to "#{m.track}", edit_audio_path(m.id)%></td>
+                <td><%= link_to "#{m.track}", edit_audio_path(m.id), 'data-no-turbolink' => true%></td>
                 <td><%= m.album %></td>
                 <td><%= m.artist %></td>
                 <td><%= m.composer %></td>

--- a/app/views/media/_media_form.html.erb
+++ b/app/views/media/_media_form.html.erb
@@ -6,4 +6,9 @@
 <%= f.text_field :year, label: "Year" %>
 <div class="required">  
 <%= f.text_field :file_name, label: "File Name" %>
+</div>
+<div class="form-group">
+  <% e_date = @media.end_date ? @media.end_date : ""%>
+  <label class="control-label" for="media_end_date">End Date</label>
+  <input type="text" name="media[end_date]" id="media_end_date" value="<%= e_date%>" size="20" placeholder="YYYY-MM-DD" class="enddatepicker form-control" data-date-format="yyyy-mm-dd"/>
 </div> 

--- a/app/views/media/_search_result.html.erb
+++ b/app/views/media/_search_result.html.erb
@@ -21,7 +21,7 @@
                 <td><fieldset><legend class="hide-label">Type</legend><%= label_tag "media_ids_#{m.id}", 'media_ids[]', class: "hide-label"%>
                 <%= check_box_tag 'media_ids[]', m.id, false, id: "media_ids_#{m.id}"%></fieldset></td>
                 <td><%=image_tag "#{thumbnailURL}", :alt => '', :class => 'search-thumbnail' %></td>          
-                <td><%= link_to "#{m.title}", edit_medium_path(m.id)%></td>
+                <td><%= link_to "#{m.title}", edit_medium_path(m.id), 'data-no-turbolink' => true %></td>
                 <td><%= m.director %></td>
                 <td><%= m.call_number %></td>
                 <td><%= m.year %></td>

--- a/app/views/shared/_menu.html.erb
+++ b/app/views/shared/_menu.html.erb
@@ -7,7 +7,7 @@
           <li class="dropdown">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Audio <span class="caret"></span></a>
             <ul class="dropdown-menu">
-              <li><a href="<%= new_audio_path%>">Create New Audio Record</a></li>
+              <li><%= link_to "Create New Audio Record", new_audio_path, 'data-no-turbolink' => true %></li>
               <li role="separator" class="divider"></li>
               <li><a href="<%= audios_path%>">View Last 10 Audio Records</a></li>
             </ul>
@@ -15,7 +15,7 @@
           <li class="dropdown">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Video <span class="caret"></span></a>
             <ul class="dropdown-menu">
-              <li><a href="<%= new_medium_path%>">Create New Video Record</a></li>
+              <li><%= link_to "Create New Video Record", new_medium_path, 'data-no-turbolink' => true %></li>
               <li role="separator" class="divider"></li>
               <li><a href="<%= media_path%>">View Last 10 Video Records</a></li>
             </ul>

--- a/db/migrate/20170626201421_add_end_date_to_audios.rb
+++ b/db/migrate/20170626201421_add_end_date_to_audios.rb
@@ -1,0 +1,5 @@
+class AddEndDateToAudios < ActiveRecord::Migration
+  def change
+    add_column :audios, :end_date, :string
+  end
+end

--- a/db/migrate/20170626201440_add_end_date_to_media.rb
+++ b/db/migrate/20170626201440_add_end_date_to_media.rb
@@ -1,0 +1,5 @@
+class AddEndDateToMedia < ActiveRecord::Migration
+  def change
+    add_column :media, :end_date, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170201220010) do
+ActiveRecord::Schema.define(version: 20170626201440) do
 
   create_table "audioreports", force: :cascade do |t|
     t.datetime "created_at", null: false
@@ -34,6 +34,7 @@ ActiveRecord::Schema.define(version: 20170201220010) do
     t.string   "file_name"
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
+    t.string   "end_date"
   end
 
   create_table "courses", force: :cascade do |t|
@@ -54,6 +55,7 @@ ActiveRecord::Schema.define(version: 20170201220010) do
     t.string   "file_name"
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
+    t.string   "end_date"
   end
 
   create_table "reports", force: :cascade do |t|

--- a/spec/fabricators/audio_fabricator.rb
+++ b/spec/fabricators/audio_fabricator.rb
@@ -4,11 +4,12 @@
 #
 
 Fabricator(:audio) do
-  track       "Test Track"
-  album       "Test Album"
-  artist      "Test Artist"
-  composer    "Test Composer"
-  call_number "Test Call Number"
-  year        "2016"
-  file_name   "pureAwareness.mp3"
+  track       'Test Track'
+  album       'Test Album'
+  artist      'Test Artist'
+  composer    'Test Composer'
+  call_number 'Test Call Number'
+  year        '2016'
+  file_name   'pureAwareness.mp3'
+  end_date '2011-11-11'
 end

--- a/spec/fabricators/media_fabricator.rb
+++ b/spec/fabricators/media_fabricator.rb
@@ -9,4 +9,5 @@ Fabricator(:media) do
   call_number 'bb77777777'
   year '2015'
   file_name 'test.mp4'
+  end_date '2011-11-11'
 end

--- a/spec/features/audio_spec.rb
+++ b/spec/features/audio_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 
 feature 'Audio' do
   before(:all) do
-    @audio1 = Audio.create track: 'Test Audio 1', album: 'Album 1', artist: 'Artist 1', composer: 'Composer 1', year: '2015', call_number: '11111111', file_name: 'pureAwareness.mp3'
+    @audio1 = Audio.create track: 'Test Audio 1', album: 'Album 1', artist: 'Artist 1', composer: 'Composer 1', year: '2015', call_number: '11111111', file_name: 'pureAwareness.mp3', end_date: '2011-11-11'
     @audio2 = Audio.create track: 'Test Audio 2', album: 'Album 2', artist: 'Artist 2', composer: 'Composer 2', year: '2016', call_number: '77777777', file_name: 'test.mp3'    
     @audio3 = Audio.create track: 'Combined Search Title', album: 'Album 3', artist: 'Artist 3', composer: 'Composer 3', year: '1999', call_number: '88888888', file_name: 'combine.mp3'    
   end
@@ -77,6 +77,7 @@ feature 'Audio' do
     expect(page).to have_selector("input#audio_year[value='2015']")
     expect(page).to have_selector("input#audio_call_number[value='11111111']")
     expect(page).to have_selector("input#audio_file_name[value='pureAwareness.mp3']")
+    expect(page).to have_selector("input#audio_end_date[value='2011-11-11']")
     page.find('.media-thumbnail')['src'].should have_content "#{Rails.configuration.audio_file_path}#{@audio1.file_name.gsub('.mp3','.jpg')}" 
 
     # Update values
@@ -86,7 +87,8 @@ feature 'Audio' do
     fill_in 'Composer', :with => 'Composer 1 Update'
     fill_in 'Year', :with => '2017'
     fill_in 'Call Number', :with => '33333333'    
-    fill_in 'File Name', :with => 'test.mp3'   
+    fill_in 'File Name', :with => 'test.mp3'
+    fill_in 'End Date', :with => '2012-12-12'   
     click_on('Save')
     expect(page).to have_content('Audio was successfully updated.')
         
@@ -98,7 +100,8 @@ feature 'Audio' do
     expect(page).to have_selector("input#audio_composer[value='Composer 1 Update']")
     expect(page).to have_selector("input#audio_year[value='2017']")
     expect(page).to have_selector("input#audio_call_number[value='33333333']")
-    expect(page).to have_selector("input#audio_file_name[value='test.mp3']")             
+    expect(page).to have_selector("input#audio_file_name[value='test.mp3']")
+    expect(page).to have_selector("input#audio_end_date[value='2012-12-12']")             
   end
   
   scenario 'wants to delete a audio record' do

--- a/spec/features/media_spec.rb
+++ b/spec/features/media_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 feature 'Video' do
   before(:all) do
     @course1 = Course.create course: 'Test Course 1', instructor: 'Test Instructor 1', year: '2015', quarter: 'Spring'
-    @media1 = Media.create title: 'Test Media 1', director: 'Test Director 1', year: '2015', call_number: '11111111', file_name: 'toystory.mp4'
+    @media1 = Media.create title: 'Test Media 1', director: 'Test Director 1', year: '2015', call_number: '11111111', file_name: 'toystory.mp4', end_date: '2011-11-11'
     @media2 = Media.create title: 'Test Media 2', director: 'Test Director 2', year: '2016', call_number: '77777777', file_name: 'file2.mp4'    
     @media3 = Media.create title: 'Combined Search Title', director: 'Director 3', year: '9999', call_number: '22222222', file_name: 'file3.mp4'    
 
@@ -73,6 +73,7 @@ feature 'Video' do
     expect(page).to have_selector("input#media_year[value='2015']")
     expect(page).to have_selector("input#media_call_number[value='11111111']")
     expect(page).to have_selector("input#media_file_name[value='toystory.mp4']")
+    expect(page).to have_selector("input#media_end_date[value='2011-11-11']")
     page.find('.media-thumbnail')['src'].should have_content "/media/#{@media1.id}/#{@media1.file_name.gsub('.mp4','.jpg')}" 
 
     # Update values
@@ -80,7 +81,8 @@ feature 'Video' do
     fill_in 'Director', :with => 'Test Director 1 Update'
     fill_in 'Year', :with => '2017'
     fill_in 'Call Number', :with => '33333333'    
-    fill_in 'File Name', :with => 'toystoryUpdate.mp4'   
+    fill_in 'File Name', :with => 'toystoryUpdate.mp4'
+    fill_in 'End Date', :with => '2012-12-12'   
     click_on('Save')
     expect(page).to have_content('Video successfully updated.')
         
@@ -90,7 +92,8 @@ feature 'Video' do
     expect(page).to have_selector("input#media_director[value='Test Director 1 Update']")
     expect(page).to have_selector("input#media_year[value='2017']")
     expect(page).to have_selector("input#media_call_number[value='33333333']")
-    expect(page).to have_selector("input#media_file_name[value='toystoryUpdate.mp4']")             
+    expect(page).to have_selector("input#media_file_name[value='toystoryUpdate.mp4']")
+    expect(page).to have_selector("input#media_end_date[value='2012-12-12']")             
   end
   
   scenario 'wants to delete a Video record' do

--- a/spec/models/audio_spec.rb
+++ b/spec/models/audio_spec.rb
@@ -1,5 +1,15 @@
+# encoding: utf-8
+#---
+# @author Vivian <tchu@ucsd.edu>
+#---
+
 require 'spec_helper'
 
-RSpec.describe Audio, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+describe Audio, type: :model do
+  it {should validate_presence_of(:track)}
+  it {should validate_presence_of(:file_name)}
+  it {should allow_value('anyFileName.mp3').for(:file_name)}
+  it {should_not allow_value('noExtensionFilename').for(:file_name)}
+  it {should have_many(:courses).through(:audioreports) }
+  it {should allow_value('2017-01-01').for(:end_date)}
 end

--- a/spec/models/media_spec.rb
+++ b/spec/models/media_spec.rb
@@ -11,4 +11,5 @@ describe Media, type: :model do
   it {should allow_value('anyFileName.mp4').for(:file_name)}
   it {should_not allow_value('noExtensionFilename').for(:file_name)}
   it {should have_many(:courses).through(:reports) }
+  it {should allow_value('2017-01-01').for(:end_date)}
 end


### PR DESCRIPTION
Fixes #172  ; refs #172

Add an End Date to the Create a New Audio Record and the Create a New Video Record. 

Changes proposed in this pull request:
* Add end_date field to existing audio and video tables
* Update audio/video controller, model and views
* Add test suites
