### PR TITLE
Add direct link function for licensed media

### DIFF
--- a/app/controllers/audios_controller.rb
+++ b/app/controllers/audios_controller.rb
@@ -3,8 +3,9 @@
 #
 class AudiosController < ApplicationController
   include Dmr::ControllerHelper
-  before_action :authorize
-  before_action :set_audio, only: [:show, :edit, :update, :destroy]
+  before_action :authorize, only: [:index, :show, :edit, :update, :new, :destroy,
+                                   :search]
+  before_action :set_audio, only: [:show, :edit, :update, :destroy, :view]
 
   # GET /audios
   def index
@@ -13,6 +14,12 @@ class AudiosController < ApplicationController
 
   # GET /audios/1
   def show
+    render layout: false
+  end
+
+  # GET /view/1/filename
+
+  def view
     render layout: false
   end
 

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -3,8 +3,9 @@
 #
 class MediaController < ApplicationController
   include Dmr::ControllerHelper
-  before_action :authorize
-  before_action :set_media, only: [:show, :edit, :update, :destroy]
+  before_action :authorize, only: [:index, :show, :edit, :update, :new, :destroy,
+                                   :search]
+  before_action :set_media, only: [:show, :edit, :update, :destroy, :view]
   ##
   # Handles GET index request to display the last 10 Media from database
   #
@@ -20,6 +21,16 @@ class MediaController < ApplicationController
   # @return [String] the resulting webpage of a single object
   #
   def show
+    render layout: false
+  end
+
+  ##
+  # Handles GET show request to display the details of a single Media object
+  # GET /view/1/filename
+  #
+  # @return [String] the resulting webpage of a single object
+  #
+  def view
     render layout: false
   end
 

--- a/app/helpers/courses_helper.rb
+++ b/app/helpers/courses_helper.rb
@@ -12,4 +12,12 @@ module CoursesHelper
   def course_report_path(course)
     "#{course.quarter}/#{course.year}/#{course.course.parameterize('_')}"
   end
+
+  def video_view_path(media)
+    "#{media.end_date}/#{media.title.parameterize('_')}"
+  end
+
+  def audio_view_path(audio)
+    "#{audio.end_date}/#{audio.track.parameterize('_')}"
+  end
 end

--- a/app/views/audios/_audio_viewer.html.erb
+++ b/app/views/audios/_audio_viewer.html.erb
@@ -1,3 +1,5 @@
+<div id="tdr_content_content" style="width:100%;max-width:100%;">
+<h3><%= obj.track%></h3>
 <%
    wowzaURL = grab_wowza_url(obj.file_name,obj.id) if !obj.nil?
 %>
@@ -24,3 +26,5 @@
 	</script>
 
 <% end %>
+</div>
+</div>

--- a/app/views/audios/_search_result.html.erb
+++ b/app/views/audios/_search_result.html.erb
@@ -46,7 +46,7 @@
   </div>
  <div class="text-center">
     <%= hidden_field_tag 'type', 'audio' %>
-    <%= f.primary "Add to Course Reserve List"%>    
+    <%= f.primary "Add to Course List"%>    
     <%= link_to "Create New Audio Record", new_audio_path, class: "btn btn-primary"%>
     <%= f.primary "Delete Selected Records", data: { confirm: 'Are you sure?' }%>
   </div>  

--- a/app/views/audios/edit.html.erb
+++ b/app/views/audios/edit.html.erb
@@ -10,8 +10,12 @@
 	      <%= render :partial => 'form' , :locals => {:f => f}%>
 	      <%= f.primary "Save"%>
 	      <%= link_to "Play File", @audio, class: "btn btn-primary", :onclick=>"window.open(this.href,'video_player', 'height=600, width=600');return false;" %>
+	      <% if @audio.end_date && !@audio.end_date.blank?%>
+	        <%#= link_to "URL", audio_view_path(@audio), class: "btn btn-primary", 'data-no-turbolink' => true , :onclick=>"window.open(this.href,'video_player', 'height=700, width=1000');return false;" %>
+            <%= link_to "URL", audio_view_path(@audio), class: "btn btn-primary", 'data-no-turbolink' => true, :onclick=>"alert(this.href);return false;" %>
+	      <% end %>
 	      <%= link_to "Delete", @audio, method: :delete, data: { confirm: 'Are you sure?' }, class: "btn btn-primary"%>
-	      <%= link_to "Add to Course Reserve List", add_to_course_courses_path(:course, :media_ids => ["#{@audio.id}"], :type => 'audio'), :method=> :post, class: "btn btn-primary"%>	     
+	      <%= link_to "Add to Course List", add_to_course_courses_path(:course, :media_ids => ["#{@audio.id}"], :type => 'audio'), :method=> :post, class: "btn btn-primary"%>	     
 	      <%= link_to "Return to Search Results", search_audios_path(:search => session[:search]), class: "btn btn-primary"%>
 	    <%end%>	    	      
 	  </div>

--- a/app/views/audios/view.html.erb
+++ b/app/views/audios/view.html.erb
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<%= render :partial => 'shared/report_header'%>
+<body>
+  <%= render :partial => 'shared/report_menu'%>
+  <div id="tdr_content" class="tdr_fonts" style="width:80%;margin-left:auto;margin-right:auto;">  
+    
+  <%= render :partial => 'audio_viewer' , :locals => {:obj => @audio}%><br/><br/>          
+  <%= render :partial => 'shared/report_footer'%>
+  
+</body>
+</html>

--- a/app/views/media/_search_result.html.erb
+++ b/app/views/media/_search_result.html.erb
@@ -34,7 +34,7 @@
     </div>
   </div>
  <div class="text-center">
-    <%= f.primary "Add to Course Reserve List"%>    
+    <%= f.primary "Add to Course List"%>    
     <%= link_to "Create New Video Record", new_medium_path, class: "btn btn-primary"%>
     <%= f.primary "Delete Selected Records", data: { confirm: 'Are you sure?' }%>
   </div>  

--- a/app/views/media/_video_viewer.html.erb
+++ b/app/views/media/_video_viewer.html.erb
@@ -1,3 +1,5 @@
+<div id="tdr_content_content" style="width:100%;max-width:100%;">
+<h3><%= obj.title%></h3>
 <%
    wowzaURL = grab_wowza_url(obj.file_name,obj.id) if !obj.nil?
 %>
@@ -25,3 +27,5 @@
 	</script>
 
 <% end %>
+</div>
+</div>

--- a/app/views/media/edit.html.erb
+++ b/app/views/media/edit.html.erb
@@ -10,8 +10,12 @@
 	      <%= render :partial => 'media_form' , :locals => {:f => f}%>
 	      <%= f.primary "Save"%>
 	      <%= link_to "Play File", medium_path(@media), class: "btn btn-primary", 'data-no-turbolink' => true , :onclick=>"window.open(this.href,'video_player', 'height=600, width=600');return false;" %>
+	      <% if @media.end_date && !@media.end_date.blank? %>
+	        <%#= link_to "URL", video_view_path(@media), class: "btn btn-primary", 'data-no-turbolink' => true , :onclick=>"window.open(this.href,'video_player', 'height=700, width=1000');return false;" %>
+            <%= link_to "URL", video_view_path(@media), class: "btn btn-primary", 'data-no-turbolink' => true, :onclick=>"alert(this.href);return false;" %>
+          <% end %>
 	      <%= link_to "Delete", @media, method: :delete, data: { confirm: 'Are you sure?' }, class: "btn btn-primary"%>
-	      <%= link_to "Add to Course Reserve List", add_to_course_courses_path(:course, :media_ids => ["#{@media.id}"]), :method=> :post, class: "btn btn-primary"%>	     
+	      <%= link_to "Add to Course List", add_to_course_courses_path(:course, :media_ids => ["#{@media.id}"]), :method=> :post, class: "btn btn-primary"%>	     
 	      <%= link_to "Return to Search Results", search_media_path(:search => session[:search]), class: "btn btn-primary"%>
 	    <%end%>	    	      
 	  </div>

--- a/app/views/media/view.html.erb
+++ b/app/views/media/view.html.erb
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<%= render :partial => 'shared/report_header'%>
+<body>
+  <%= render :partial => 'shared/report_menu'%>
+  <div id="tdr_content" class="tdr_fonts" style="width:80%;margin-left:auto;margin-right:auto;">  
+    
+	<%= render :partial => 'video_viewer' , :locals => {:obj => @media}%>          
+  <%= render :partial => 'shared/report_footer'%>
+  
+</body>
+</html>

--- a/app/views/shared/_report_menu.html.erb
+++ b/app/views/shared/_report_menu.html.erb
@@ -49,9 +49,11 @@
 		</div><!-- /tdr_search -->
 			<div id="tdr_crumbs">
 		<div id="tdr_crumbs_content">
+		  <% if @course %>
 			<ul>
-				<li><a href="http://libraries.ucsd.edu/index.html">Home</a></li>
-				<li>Digital Media Reserves - <%= @course.course + " " + @course.quarter + " " + @course.year %></li>
+				<li><a href="http://libraries.ucsd.edu/index.html">Home</a></li>				
+				<li>Digital Media Reserves - <%= @course.course + " " + @course.quarter + " " + @course.year %></li>				
 			</ul>
+		  <% end %>
 		</div><!-- /tdr_crumbs_content -->
 	</div><!-- /tdr_crumbs -->

--- a/config/deploy/pontos.rb
+++ b/config/deploy/pontos.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 set :stage, :pontos
-set :branch, 'develop'
+set :branch, 'feature/direct_link'
 server 'pontos.ucsd.edu', user: 'conan', roles: %w{app db}
 set :rails_env, 'pontos'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,9 @@ Rails.application.routes.draw do
     
   get 'media/:id/:ds', :to => 'file#show', :constraints => { :ds => /[^\/]+/ }, :as => 'file'  
   get 'courses/:id/:quarter/:year/:course', :to => 'courses#show', constraints: CourseConstraint.new, :as => :course_report
+  get 'media/:id/:end_date/:title', :to => 'media#view', :as => 'video_view'
+  get 'audios/:id/:end_date/:track', :to => 'audios#view', :as => 'audio_view'
+
  
   get '/auth/shibboleth', as: :shibboleth
   get '/auth/developer', to: 'users/sessions#developer', as: :developer

--- a/spec/features/audio_spec.rb
+++ b/spec/features/audio_spec.rb
@@ -231,5 +231,15 @@ feature 'Audio' do
     visit audios_path
     expect(page).to have_content('Test Audio')
     expect(page).to have_content('testspacename.mp3')                  
-  end                                    
+  end
+  
+  scenario 'expects to see a friendly url for an audio record with end_date' do
+    # set current course   
+    visit edit_audio_path(@audio1) 
+
+    expect(page).to have_link('URL', href: '2011-11-11/test_audio_1' )
+    click_on 'URL'
+    
+    current_path.should == "/audios/#{@audio1.id}/#{@audio1.end_date}/#{@audio1.track.parameterize("_")}"           
+  end                                      
 end

--- a/spec/features/course_spec.rb
+++ b/spec/features/course_spec.rb
@@ -125,7 +125,7 @@ feature 'Course' do
 
   scenario 'wants to add a media object to the current Course Reserve List when no current course is set' do
     visit edit_medium_path(@media1)
-    click_on 'Add to Course Reserve List'
+    click_on 'Add to Course List'
     expect(page).to have_content('No current Course is set.  Set the Course first.')     
   end  
     
@@ -135,7 +135,7 @@ feature 'Course' do
     
     #add to course list  
     visit edit_medium_path(@media1)
-    click_on 'Add to Course Reserve List'
+    click_on 'Add to Course List'
     
     #Check that changes are saved
     expect(page).to have_content('Video was successfully added to Course.')
@@ -151,7 +151,7 @@ feature 'Course' do
     
     #add to course list  
     visit edit_audio_path(@audio1)
-    click_on 'Add to Course Reserve List'
+    click_on 'Add to Course List'
     
     #Check that changes are saved
     expect(page).to have_content('Audio was successfully added to Course.')
@@ -174,7 +174,7 @@ feature 'Course' do
     # add to course list    
     find("input[type='checkbox'][value='#{@media1.id}']").set(true)
     find("input[type='checkbox'][value='#{@media2.id}']").set(true)
-    click_on 'Add to Course Reserve List'
+    click_on 'Add to Course List'
     
     #Check that changes are saved
     expect(page).to have_content('Video was successfully added to Course.')
@@ -199,7 +199,7 @@ feature 'Course' do
     # add to course list    
     find("input[type='checkbox'][value='#{@audio1.id}']").set(true)
     find("input[type='checkbox'][value='#{@audio2.id}']").set(true)
-    click_on 'Add to Course Reserve List'
+    click_on 'Add to Course List'
     
     #Check that changes are saved
     expect(page).to have_content('Audio was successfully added to Course.')
@@ -269,7 +269,7 @@ feature 'Course' do
     # add to course list    
     find("input[type='checkbox'][value='#{@media1.id}']").set(true)
     find("input[type='checkbox'][value='#{@media2.id}']").set(true)
-    click_on 'Add to Course Reserve List'
+    click_on 'Add to Course List'
     
     #Check that changes are saved
     expect(page).to have_content('Video was successfully added to Course.')
@@ -305,7 +305,7 @@ feature 'Course' do
     # add to course list    
     find("input[type='checkbox'][value='#{@audio1.id}']").set(true)
     find("input[type='checkbox'][value='#{@audio2.id}']").set(true)
-    click_on 'Add to Course Reserve List'
+    click_on 'Add to Course List'
     
     #Check that changes are saved
     expect(page).to have_content('Audio was successfully added to Course.')
@@ -334,7 +334,7 @@ feature 'Course' do
     
     # add media to course 
     visit edit_medium_path(@media1)
-    click_on 'Add to Course Reserve List'  
+    click_on 'Add to Course List'  
 
     #Check that changes are saved
     expect(page).to have_content('Video was successfully added to Course.')
@@ -359,7 +359,7 @@ feature 'Course' do
     
     # add media to course 
     visit edit_audio_path(@audio1)
-    click_on 'Add to Course Reserve List'  
+    click_on 'Add to Course List'  
 
     #Check that changes are saved
     expect(page).to have_content('Audio was successfully added to Course.')
@@ -399,7 +399,7 @@ feature 'Course' do
     find("input[type='checkbox'][value='#{@media8.id}']").set(true)
     find("input[type='checkbox'][value='#{@media9.id}']").set(true)
     find("input[type='checkbox'][value='#{@media10.id}']").set(true)    
-    click_on 'Add to Course Reserve List'
+    click_on 'Add to Course List'
     
     #Check that changes are saved
     expect(page).to have_content('Video was successfully added to Course.')
@@ -439,7 +439,7 @@ feature 'Course' do
     find("input[type='checkbox'][value='#{@media8.id}']").set(true)
     find("input[type='checkbox'][value='#{@media9.id}']").set(true)
     find("input[type='checkbox'][value='#{@media10.id}']").set(true)       
-    click_on 'Add to Course Reserve List'
+    click_on 'Add to Course List'
     
     #Check that changes are saved
     expect(page).to have_content('Video was successfully added to Course.')
@@ -471,7 +471,7 @@ feature 'Course' do
     # add to course list    
     find("input[type='checkbox'][value='#{@audio1.id}']").set(true)
     find("input[type='checkbox'][value='#{@audio2.id}']").set(true)
-    click_on 'Add to Course Reserve List'
+    click_on 'Add to Course List'
     
     #Check that changes are saved
     expect(page).to have_content('Audio was successfully added to Course.')
@@ -503,7 +503,7 @@ feature 'Course' do
     # add to course list    
     find("input[type='checkbox'][value='#{@audio1.id}']").set(true)
     find("input[type='checkbox'][value='#{@audio2.id}']").set(true)
-    click_on 'Add to Course Reserve List'
+    click_on 'Add to Course List'
     
     #Check that changes are saved
     expect(page).to have_content('Audio was successfully added to Course.')
@@ -535,7 +535,7 @@ feature 'Course' do
     # add to course list    
     find("input[type='checkbox'][value='#{@media1.id}']").set(true)
     find("input[type='checkbox'][value='#{@media2.id}']").set(true)
-    click_on 'Add to Course Reserve List'
+    click_on 'Add to Course List'
     
     # check the friendly url for view button
     expect(page).to have_link('View', href: 'Spring/2015/test_course_1' )

--- a/spec/features/media_spec.rb
+++ b/spec/features/media_spec.rb
@@ -195,7 +195,7 @@ feature 'Video' do
     # add to course list    
     find("input[type='checkbox'][value='#{@media1.id}']").set(true)
     find("input[type='checkbox'][value='#{@media2.id}']").set(true)
-    click_on 'Add to Course Reserve List'
+    click_on 'Add to Course List'
     
     # check that Video records are added
     expect(page).to have_content('Video was successfully added to Course.')
@@ -225,5 +225,15 @@ feature 'Video' do
   scenario "wants to see the Procedures and Policy link" do
     visit root_path
     expect(page).to have_link('Procedures and Policy')
-  end                               
+  end
+  
+  scenario 'expects to see a friendly url for a video record with end_date' do
+    # set current course   
+    visit edit_medium_path(@media1) 
+    
+    expect(page).to have_link('URL', href: '2011-11-11/test_media_1' )
+    click_on 'URL'
+    
+    current_path.should == "/media/#{@media1.id}/#{@media1.end_date}/#{@media1.title.parameterize("_")}"           
+  end                                 
 end


### PR DESCRIPTION
Fixes #173  ; refs #173 

Add Direct Link to “Media Record Core Data”/ “Audio Record Core Data” page.

Changes proposed in this pull request:
* Add direct link function
* Update access control to allow user to view a single media/audio page without login
* Add test suites

@ucsdlib/developers - please review
