### PR TITLE
Add auto update video/audio record direct link function

### DIFF
--- a/config/deploy/pontos.rb
+++ b/config/deploy/pontos.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 set :stage, :pontos
-set :branch, 'feature/direct_link'
+set :branch, 'develop'
 server 'pontos.ucsd.edu', user: 'conan', roles: %w{app db}
 set :rails_env, 'pontos'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,17 @@ class CourseConstraint
     true
   end  
 end
+
+class MediaConstraint
+  def matches?(request)
+    obj = request.fullpath.split(/\//)[1].capitalize
+    obj = obj.singularize if !obj.include? 'Media'
+    params = request.path_parameters
+    tmp = obj.constantize.find(params[:id])
+    return false if params[:end_date] != tmp.end_date
+    true
+  end  
+end
   
 Rails.application.routes.draw do
   root 'welcome#index'
@@ -39,10 +50,9 @@ Rails.application.routes.draw do
     
   get 'media/:id/:ds', :to => 'file#show', :constraints => { :ds => /[^\/]+/ }, :as => 'file'  
   get 'courses/:id/:quarter/:year/:course', :to => 'courses#show', constraints: CourseConstraint.new, :as => :course_report
-  get 'media/:id/:end_date/:file_name', :to => 'media#view', :as => 'video_view'
-  get 'audios/:id/:end_date/:file_name', :to => 'audios#view', :as => 'audio_view'
+  get 'media/:id/:end_date/:file_name', :to => 'media#view', constraints: MediaConstraint.new, :as => 'video_view'
+  get 'audios/:id/:end_date/:file_name', :to => 'audios#view', constraints: MediaConstraint.new, :as => 'audio_view'
 
- 
   get '/auth/shibboleth', as: :shibboleth
   get '/auth/developer', to: 'users/sessions#developer', as: :developer
   match '/auth/shibboleth/callback' => 'users/sessions#shibboleth', as: :callback, via: [:get, :post]

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -2,4 +2,5 @@ set :output, {:error => "log/cron_error_log.log", :standard => "log/cron_log.log
 
 every :friday, :at => '10pm'  do
   rake "autoarchive"
+  rake "changeurl"
 end

--- a/lib/tasks/changeurl.rake
+++ b/lib/tasks/changeurl.rake
@@ -1,0 +1,20 @@
+# bundle exec rake changeurl
+desc 'ChangeUrl media object'
+task :changeurl, [:filename] => :environment do
+  current_date = DateTime.current.strftime('%Y-%m-%d')
+  q = "end_date != '' AND end_date NOT LIKE '%EXPIRED%'"
+  update_url(Media, q, current_date)
+  update_url(Audio, q, current_date)
+end
+
+def update_url(object_type, query, current_date)
+  results = object_type.where(query)
+  results.each do |c|
+    tmp_date = DateTime.strptime(c.end_date, '%Y-%m-%d')
+    next unless tmp_date.to_date.to_s < current_date
+    c.end_date = "#{c.end_date} - EXPIRED #{c.updated_at}"
+    c.save!
+    Rails.logger.info "ChangeUrl  #{DateTime.current} - id - #{c.id} - endDate #{c.end_date}"
+  end
+  Rails.logger.flush
+end


### PR DESCRIPTION
Fixes #181  ; refs #181 

Create a function to return record links without access control (for single video or audio record) that have end dates. When the end dates expire the links should be auto-updated so that they are no longer accessible.

@ucsdlib/developers - please review
