### PR TITLE
Update audio player to use hls

### DIFF
--- a/app/views/audios/_audio_viewer.html.erb
+++ b/app/views/audios/_audio_viewer.html.erb
@@ -14,13 +14,11 @@
 			[{
 				sources:
 				[
-				    {file: "rtmps://<%=wowzaURL%>"},
 					{file: "https://<%=wowzaURL%>/playlist.m3u8"}					
 				]
 			}],
 			width: "100%",
 			height: "30",
-			rtmp: {bufferlength: 3},
 			analytics: {enabled: false}
 		});
 	</script>

--- a/app/views/courses/_audio_playlist.html.erb
+++ b/app/views/courses/_audio_playlist.html.erb
@@ -17,8 +17,7 @@
             end          
           %>
           sources: [
-	        {file: "rtmps://<%=wowzaURL%>"},      
-	        {file: "https://<%=wowzaURL%>/manifest.mpd"}
+	        {file: "https://<%=wowzaURL%>/playlist.m3u8"}
 	      ],
 	      <!--title of media file-->
 	      title: "<%= m.track %>",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,10 +10,9 @@ end
 
 class MediaConstraint
   def matches?(request)
-    obj = request.fullpath.split(/\//)[1].capitalize
-    obj = obj.singularize if !obj.include? 'Media'
+    obj = request.fullpath.include?('media') ? Media : Audio
     params = request.path_parameters
-    tmp = obj.constantize.find(params[:id])
+    tmp = obj.find(params[:id])
     return false if params[:end_date] != tmp.end_date
     true
   end  


### PR DESCRIPTION
Fixes #187  ; refs #187 

Update audio player to use HLS streaming protocol instead of RTMP to allow mp3 to play in all browsers with flash disable.

@ucsdlib/developers - please review
